### PR TITLE
fix: include raw remaining input as suffix in romaji_to_hiragana_predictively

### DIFF
--- a/src/migemo/romaji_processor.rs
+++ b/src/migemo/romaji_processor.rs
@@ -167,6 +167,12 @@ impl RomajiProcessor {
                         set.insert(value_buffer.clone());
                     }
                 }
+                // Also include the raw remaining input as a suffix option.
+                // This ensures that e.g. querying "infurawbs" against "インフラWBS" works:
+                // the trailing "s" (a romaji prefix for sa/si/su/…) must also match as the
+                // plain ASCII character 's', otherwise the generated pattern only contains
+                // kana alternatives like [サシスセソ…] and misses the ASCII 'S'.
+                set.insert(query.to_vec());
                 return RomajiPredictiveResult {
                     prefix: hiragana,
                     suffixes: set.into_iter().collect(),
@@ -398,7 +404,9 @@ mod tests {
     #[test]
     fn romaji_to_hiragana_predictively_2() {
         let (prefix, suffixes) = romaji_to_hiragana_predictively("ky");
-        let mut expected_suffixes = vec!["きゃ", "きぃ", "きぇ", "きゅ", "きょ"];
+        // "ky" itself is included as a raw-ASCII suffix so callers can also generate
+        // a literal "ky" pattern alongside the kana alternatives.
+        let mut expected_suffixes = vec!["ky", "きゃ", "きぃ", "きぇ", "きゅ", "きょ"];
         expected_suffixes.sort();
         assert_eq!(prefix, "");
         assert_eq!(suffixes, expected_suffixes);
@@ -407,7 +415,8 @@ mod tests {
     #[test]
     fn romaji_to_hiragana_predictively_3() {
         let (prefix, suffixes) = romaji_to_hiragana_predictively("kky");
-        let mut expected_suffixes = vec!["きゃ", "きぃ", "きぇ", "きゅ", "きょ"];
+        // "ky" is included as a raw-ASCII suffix (same reason as test 2).
+        let mut expected_suffixes = vec!["ky", "きゃ", "きぃ", "きぇ", "きゅ", "きょ"];
         expected_suffixes.sort();
         assert_eq!(prefix, "っ");
         assert_eq!(suffixes, expected_suffixes);
@@ -416,8 +425,9 @@ mod tests {
     #[test]
     fn romaji_to_hiragana_predictively_4() {
         let (prefix, suffixes) = romaji_to_hiragana_predictively("n");
+        // "n" itself is included as a raw-ASCII suffix alongside kana alternatives.
         let mut expected_suffixes = vec![
-            "にょ", "の", "にゃ", "ぬ", "ね", "な", "にぇ", "にゅ", "に", "ん", "にぃ",
+            "n", "にょ", "の", "にゃ", "ぬ", "ね", "な", "にぇ", "にゅ", "に", "ん", "にぃ",
         ];
         expected_suffixes.sort();
         assert_eq!(prefix, "");
@@ -434,5 +444,44 @@ mod tests {
     #[test]
     fn romaji_to_hiragana_predictively_w() {
         let (_, _) = romaji_to_hiragana_predictively("w");
+    }
+
+    // --- regression: trailing romaji consonant must include the raw ASCII suffix ---
+    //
+    // When a query like "infurawbs" is processed, the trailing "s" is an incomplete
+    // romaji syllable (prefix of sa/si/su/…).  Before the fix, the suffix set only
+    // contained kana alternatives ([さしすせそ…]) and never the plain ASCII "s", so
+    // the query could not match a filename like "インフラWBS".
+    //
+    // After the fix the raw remaining input ("s") is added as one extra suffix, which
+    // lets query_a_word generate the pattern "インフラwbs" (matched case-insensitively).
+
+    #[test]
+    fn predictive_suffix_includes_raw_ascii_trailing_consonant() {
+        // "infurawbs": after consuming "infura"→"いんふら", remaining is "wbs".
+        // "w" and "b" pass through as-is; "s" triggers suffix generation.
+        // The suffix set must contain the raw "s" so that "インフラwbs" is generated.
+        let (prefix, suffixes) = romaji_to_hiragana_predictively("infurawbs");
+        assert_eq!(prefix, "いんふらwb");
+        assert!(
+            suffixes.iter().any(|s| s == "s"),
+            "expected raw 's' in suffixes, got: {:?}",
+            suffixes
+        );
+        // kana alternatives must still be present
+        assert!(suffixes.iter().any(|s| s == "す" || s == "さ" || s == "せ"));
+    }
+
+    #[test]
+    fn predictive_suffix_includes_raw_for_single_trailing_consonant() {
+        // "denks": after "でん", remaining "k" is consumed as prefix then "s" triggers.
+        // Simpler case: just "s" alone as the remaining.
+        let (prefix, suffixes) = romaji_to_hiragana_predictively("s");
+        assert_eq!(prefix, "");
+        assert!(
+            suffixes.iter().any(|s| s == "s"),
+            "expected raw 's' in suffixes, got: {:?}",
+            suffixes
+        );
     }
 }


### PR DESCRIPTION
## Problem

When a query contains a kana-convertible prefix followed by an incomplete romaji
syllable (a bare consonant), mixed kana+ASCII filenames fail to match.

**Concrete example** (found in a Japanese launcher app using rustmigemo):

| Filename | Query | Expected | Actual |
|----------|-------|----------|--------|
| `インフラWBS` | `infura` | match ✓ | match ✓ |
| `インフラWBS` | `wbs` | match ✓ | match ✓ |
| `インフラWBS` | `infurawbs` | match ✓ | **no match ✗** |

### Root cause

`romaji_to_hiragana_predictively("infurawbs")` processes the string as:

1. `infura` → consumed into prefix as `いんふら`
2. `w`, `b` → pushed as-is (no romaji match)
3. `s` → triggers the predictive suffix block (`terminal_nodes_for_prefix("s").len() > 1`)

Inside the suffix block, only kana alternatives are inserted into the set
(`[さ, し, す, せ, そ, …]`).  The plain ASCII `s` is never added.

As a result, `query_a_word_with_generator` generates patterns like
`インフラwb[サシスセソ…]` but **not** `インフラwbs`.  The case-insensitive regex
`(?i)インフラwb[サシスセソ…]` cannot match `インフラWBS` because `S ≠ サ`.

By contrast, querying `"wbs"` alone works because `query_a_word_with_generator`
adds the literal word via `generator.add(&word_chars)` at the top, so `wbs` is
already present as a pattern alternative.  The problem only surfaces when the
ASCII tail is preceded by a kana-converted prefix.

## Fix

One line added to `romaji_to_hiragana_predictively` — insert the raw remaining
input as an additional suffix option before returning:

```rust
// Also include the raw remaining input as a suffix option.
set.insert(query.to_vec());
```

With this change the suffix set for the trailing `s` becomes
`[さ, し, す, …, s]`, so `query_a_word_with_generator` also generates
`インフラwbs` → `(?i)インフラwbs` matches `インフラWBS`. ✓

## Side-effects analysis

The extra suffix is **redundant in the no-prefix case**: when the query starts
with an incomplete romaji syllable (`"ky"`, `"n"`, …) the raw input is already
added to the regex generator via `generator.add(&word_chars)` at the top of
`query_a_word_with_generator`, so the final regex pattern is unchanged.

In the mixed case (`"infurawbs"`) the raw suffix produces genuinely new
alternatives (`インフラwbs`, `いんふらwbs`) that were previously missing.

## Tests

- Three existing predictive tests updated to include the raw suffix in expected
  results (behavior change is intentional and correct).
- Two new regression tests added:
  - `predictive_suffix_includes_raw_ascii_trailing_consonant` — verifies `"infurawbs"` yields `"s"` in suffixes
  - `predictive_suffix_includes_raw_for_single_trailing_consonant` — verifies `"s"` alone yields `"s"` in suffixes

All 55 tests pass.